### PR TITLE
[commhistory-daemon] Reset voicemail notification on number change.

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -910,7 +910,7 @@ void NotificationManager::slotVoicemailWaitingChanged()
             path = VOICECALL_OBJECT_PATH;
             iface = VOICECALL_INTERFACE;
             method = VOICECALL_DIAL_METHOD;
-            args.append(QVariant(QVariantList() << QString(QStringLiteral("tel://")) + voicemailNumber));
+            args.append(voicemailNumber);
         } else {
             service = CALL_HISTORY_SERVICE_NAME;
             path = CALL_HISTORY_OBJECT_PATH;


### PR DESCRIPTION
I'm impacted by https://forum.sailfishos.org/t/4-0-1-voicemail-notifications-dont-call-voicemail-when-clicked/5049

When I tap on the notification, I'm brought to the call history, even if I've a voicemail number registered and working (long press on 1 in the dialer call the voicemail).

To reproduce on a JollaC:
- get a voice mail,
- tap on the notification, it send you to the call history,
- restart `commhistoryd` and tap on the notification, it calls the voice mail,
- restart `ofono` and tap on the notification, it brings you to the call history.

Investigating a bit, the choice between the two destination (voicemail or call history) is based on the voicemail number reported by the QOfonoMessageWaiting object. And it seems that the voicemail number is no always ready when the other properties are.

So the PR is simple : also update the notification when the voicemail number becomes available.

@pvuorela what do you think ?