### PR TITLE
[packaging] BuildRequire systemd via pkgconfig. JB#55010

### DIFF
--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -25,8 +25,8 @@ BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  libqofono-qt5-devel >= 0.89
 BuildRequires:  libqofonoext-devel
+BuildRequires:  pkgconfig(systemd)
 BuildRequires:  python3-base
-BuildRequires:  systemd
 Requires:  libcommhistory-qt5 >= 1.9.33
 Requires:  libqofono-qt5 >= 0.66
 Requires:  mapplauncherd-qt5


### PR DESCRIPTION
This allows to pick systemd-mini inside the builder instead of full
systemd.