### PR TITLE
[commhistory] Use feedback events instead of notification categories. Fixes JB#56404

### DIFF
--- a/data/notifications/x-nemo.call.missed.conf
+++ b/data/notifications/x-nemo.call.missed.conf
@@ -1,4 +1,0 @@
-app_icon=icon-lock-missed-call
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=call_exists

--- a/data/notifications/x-nemo.call.missed.group.conf
+++ b/data/notifications/x-nemo.call.missed.group.conf
@@ -1,4 +1,0 @@
-app_icon=icon-lock-missed-call
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=call_exists

--- a/data/notifications/x-nemo.messaging.group.conf
+++ b/data/notifications/x-nemo.messaging.group.conf
@@ -1,4 +1,0 @@
-app_icon=icon-lock-sms
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms_exists

--- a/data/notifications/x-nemo.messaging.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.group.preview.conf
@@ -1,6 +1,0 @@
-app_icon=icon-lock-sms
-transient=true
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms
-x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.im.conf
+++ b/data/notifications/x-nemo.messaging.im.conf
@@ -1,4 +1,0 @@
-app_icon=icon-lock-sms
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=chat_exists

--- a/data/notifications/x-nemo.messaging.im.preview.conf
+++ b/data/notifications/x-nemo.messaging.im.preview.conf
@@ -1,6 +1,0 @@
-app_icon=icon-lock-sms
-transient=true
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=chat
-x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.mms.conf
+++ b/data/notifications/x-nemo.messaging.mms.conf
@@ -1,4 +1,0 @@
-app_icon=icon-lock-sms
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms_exists

--- a/data/notifications/x-nemo.messaging.mms.preview.conf
+++ b/data/notifications/x-nemo.messaging.mms.preview.conf
@@ -1,6 +1,0 @@
-app_icon=icon-lock-sms
-transient=true
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms
-x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.sms.conf
+++ b/data/notifications/x-nemo.messaging.sms.conf
@@ -1,4 +1,0 @@
-app_icon=icon-lock-sms
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms_exists

--- a/data/notifications/x-nemo.messaging.sms.preview.conf
+++ b/data/notifications/x-nemo.messaging.sms.preview.conf
@@ -1,6 +1,0 @@
-app_icon=icon-lock-sms
-transient=true
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms
-x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.conf
@@ -1,4 +1,0 @@
-app_icon=icon-lock-sms
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms_exists

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
@@ -1,6 +1,0 @@
-app_icon=icon-lock-sms
-transient=true
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms
-x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.conf
@@ -1,5 +1,0 @@
-app_icon=icon-lock-voicemail
-x-nemo-display-on=true
-x-nemo-user-removable=false
-x-nemo-priority=120
-x-nemo-feedback=sms_exists

--- a/data/notifications/x-nemo.messaging.voicemail.group.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.conf
@@ -1,5 +1,0 @@
-app_icon=icon-lock-voicemail
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-user-removable=false
-x-nemo-feedback=sms_exists

--- a/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
@@ -1,6 +1,0 @@
-app_icon=icon-lock-voicemail
-transient=true
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms
-x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.preview.conf
@@ -1,6 +1,0 @@
-app_icon=icon-lock-voicemail
-transient=true
-x-nemo-display-on=true
-x-nemo-priority=120
-x-nemo-feedback=sms
-x-nemo-display-on=true


### PR DESCRIPTION
Skip usage of the notification categories and instead use appropriate list of ngf event types.