### PR TITLE
SMS text reply support on notifications

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -39,6 +39,7 @@
 #define MESSAGING_INTERFACE       QLatin1String("org.sailfishos.Messages")
 #define SHOW_INBOX_METHOD         QLatin1String("showGroupsWindow")
 #define START_CONVERSATION_METHOD QLatin1String("startConversation")
+#define SEND_MESSAGE_METHOD       QLatin1String("sendMessage")
 
 #define CALL_HISTORY_SERVICE_NAME QLatin1String("com.nokia.telephony.callhistory")
 #define CALL_HISTORY_OBJECT_PATH  QLatin1String("/org/maemo/m")

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -636,15 +636,17 @@ void NotificationManager::setNotificationProperties(Notification *notification, 
 
                 if (pn->eventType() == CommHistory::Event::IMEvent || pn->hasPhoneNumber()) {
                     // Named action: "Reply"
-                    remoteActions.append(dbusAction(QString(),
-                                                    txt_qtn_msg_notification_reply,
-                                                    MESSAGING_SERVICE_NAME,
-                                                    OBJECT_PATH,
-                                                    MESSAGING_INTERFACE,
-                                                    START_CONVERSATION_METHOD,
-                                                    QVariantList() << pn->account()
-                                                                   << pn->targetId()
-                                                                   << true));
+                    QVariantMap action
+                            = dbusAction(QString(),
+                                         txt_qtn_msg_notification_reply,
+                                         MESSAGING_SERVICE_NAME,
+                                         OBJECT_PATH,
+                                         MESSAGING_INTERFACE,
+                                         SEND_MESSAGE_METHOD,
+                                         QVariantList() << pn->account() << pn->targetId())
+                            .toMap();
+                    action.insert(QLatin1String("type"), QLatin1String("input"));
+                    remoteActions.append(action);
                 }
             }
 

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -119,28 +119,29 @@ static QString groupName(PersonalNotification::EventCollection collection)
 }
 
 
-PersonalNotification::PersonalNotification(QObject* parent) : QObject(parent),
-    m_eventType(CommHistory::Event::UnknownType),
-    m_chatType(CommHistory::Group::ChatTypeP2P),
-    m_hasPendingEvents(false),
-    m_notification(0)
+PersonalNotification::PersonalNotification(QObject* parent)
+    : QObject(parent)
+    , m_eventType(CommHistory::Event::UnknownType)
+    , m_chatType(CommHistory::Group::ChatTypeP2P)
+    , m_hasPendingEvents(false)
+    , m_notification(0)
 {
 }
 
-PersonalNotification::PersonalNotification(const QString& remoteUid,
-                                           const QString& account,
+PersonalNotification::PersonalNotification(const QString &remoteUid,
+                                           const QString &account,
                                            CommHistory::Event::EventType eventType,
-                                           const QString& channelTargetId,
+                                           const QString &channelTargetId,
                                            CommHistory::Group::ChatType chatType,
                                            uint contactId,
-                                           const QString& lastNotification,
-                                          QObject* parent) :
-    QObject(parent), m_remoteUid(remoteUid), m_account(account),
-    m_eventType(eventType), m_targetId(channelTargetId), m_chatType(chatType),
-    m_notificationText(lastNotification),
-    m_hasPendingEvents(true),
-    m_notification(0),
-    m_recipient(account, remoteUid)
+                                           const QString &lastNotification,
+                                           QObject *parent)
+    : QObject(parent), m_remoteUid(remoteUid), m_account(account)
+    , m_eventType(eventType), m_targetId(channelTargetId), m_chatType(chatType)
+    , m_notificationText(lastNotification)
+    , m_hasPendingEvents(true)
+    , m_notification(0)
+    , m_recipient(account, remoteUid)
 {
 }
 
@@ -251,8 +252,9 @@ QString PersonalNotification::notificationName() const
     } else if (CommHistory::localUidComparesPhoneNumbers(account())) {
         ML10N::MLocale locale;
         return locale.toLocalizedNumbers(remoteUid());
-    } else
+    } else {
         return remoteUid();
+    }
 }
 
 PersonalNotification::EventCollection PersonalNotification::collection() const
@@ -303,7 +305,6 @@ uint PersonalNotification::contactId() const
 {
     return m_recipient.contactId();
 }
-
 
 QString PersonalNotification::notificationText() const
 {


### PR DESCRIPTION
Switch the 'reply' action to use inline text field on notifications.
Another commit for some minor coding convention adjustments.

@mlehtima @Tomin1 @abranson 