### PR TITLE
[commhistory-daemon] Use CommHistory::UpdatesListener for DBus listening.

### DIFF
--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -3,7 +3,7 @@ Summary:    Communications event history database daemon
 Version:    0.8.41
 Release:    1
 License:    LGPLv2
-URL:        https://git.sailfishos.org/mer-core/commhistory-daemon
+URL:        https://github.com/sailfishos/commhistory-daemon
 Source0:    %{name}-%{version}.tar.bz2
 Source1:    %{name}.privileges
 BuildRequires:  pkgconfig(Qt5Core)


### PR DESCRIPTION
Replace the direct DBus connection to the bus
with the CommHistory::Adaptor object, so the
DBus registration can be handled transparently
by libcommhistory.

@pvuorela this commit may remove the requirement to export serialisation of CommHistory objects over DBus.