### PR TITLE
[commhistoryd] Use const reference in loop. JB#62204

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -966,7 +966,7 @@ void NotificationManager::slotValidChanged(bool valid)
 void NotificationManager::slotEventUpdated(const QList<Event> &events)
 {
     qCDebug(lcCommhistoryd) << "NotificationManager::slotEventAdded nember of new events: " << events.count();
-    for (const Event event : events) {
+    for (const Event &event : events) {
         if (event.isMissedCall()) {
             showNotification(event);
         }


### PR DESCRIPTION
Fixes build with gcc 11 or newer.