### PR TITLE
[commhistory-daemon] Notify for call not answered.

### DIFF
--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -11,7 +11,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(Qt5Test)
-BuildRequires:  pkgconfig(commhistory-qt5) >= 1.12.5
+BuildRequires:  pkgconfig(commhistory-qt5) >= 1.12.6
 BuildRequires:  pkgconfig(contactcache-qt5)
 BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions)
 BuildRequires:  pkgconfig(TelepathyQt5) >= 0.9.8

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -113,8 +113,8 @@ void NotificationManager::init()
             SLOT(slotContactInfoChanged(RecipientList)));
 
     m_eventListener = new UpdatesListener(this);
-    connect(m_eventListener, &UpdatesListener::eventsUpdated,
-            this, &NotificationManager::slotEventUpdated);
+    connect(m_eventListener, &UpdatesListener::eventsAdded,
+            this, &NotificationManager::slotEventsAdded);
 
     m_ngfClient = new Ngf::Client(this);
     connect(m_ngfClient, SIGNAL(eventFailed(quint32)), SLOT(slotNgfEventFinished(quint32)));
@@ -963,11 +963,11 @@ void NotificationManager::slotValidChanged(bool valid)
     }
 }
 
-void NotificationManager::slotEventUpdated(const QList<Event> &events)
+void NotificationManager::slotEventsAdded(const QList<Event> &events)
 {
-    qCDebug(lcCommhistoryd) << "NotificationManager::slotEventAdded nember of new events: " << events.count();
+    qCDebug(lcCommhistoryd) << "NotificationManager::slotEventsAdded received new events: " << events.count();
     for (const Event &event : events) {
-        if (event.isMissedCall()) {
+        if (event.incomingStatus() == CommHistory::Event::NotAnswered) {
             showNotification(event);
         }
     }

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -136,7 +136,7 @@ private Q_SLOTS:
     void slotModemRemoved(QString path);
     void slotModemsChanged(QStringList modems);
     void slotValidChanged(bool valid);
-    void slotEventUpdated(const QList<CommHistory::Event> &events);
+    void slotEventsAdded(const QList<CommHistory::Event> &events);
 
 private:
     NotificationManager( QObject* parent = 0);


### PR DESCRIPTION
Missed calls can have various reasons with
call filtering. Only notifies for missed
calls when presented but not answered.