### PR TITLE
[commhistoryd] Remove unnecessary use of qtcontacts-sqlite-qt5-extensions. JB#62478

### DIFF
--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -12,8 +12,6 @@ BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(commhistory-qt5) >= 1.12.6
-BuildRequires:  pkgconfig(contactcache-qt5)
-BuildRequires:  pkgconfig(qtcontacts-sqlite-qt5-extensions)
 BuildRequires:  pkgconfig(TelepathyQt5) >= 0.9.8
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(mlocale5)
@@ -56,7 +54,6 @@ Daemon for logging communications (IM, SMS and call) in history database.
 %setup -q -n %{name}-%{version}
 
 %build
-unset LD_AS_NEEDED
 %qmake5
 %make_build
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -36,7 +36,7 @@ QT -= gui
 
 PKGCONFIG += ngf-qt5 mce nemonotifications-qt5
 PKGCONFIG += TelepathyQt5 commhistory-qt5 mlite5 mlocale5
-PKGCONFIG += qofono-qt5 qofonoext contactcache-qt5 qtcontacts-sqlite-qt5-extensions
+PKGCONFIG += qofono-qt5 qofonoext
 # clock_gettime
 LIBS += -lrt
 

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -32,8 +32,7 @@ INCLUDEPATH += . .. \
 
 TEST_SOURCES += $$PWD/testdebug.cpp
 
-PKGCONFIG += mlite5 commhistory-qt5 nemonotifications-qt5 qofono-qt5 \
-             contactcache-qt5 qtcontacts-sqlite-qt5-extensions
+PKGCONFIG += mlite5 commhistory-qt5 nemonotifications-qt5 qofono-qt5
 
 COMMHISTORYDSRCDIR = ../../src
 DEPENDPATH  += $${INCLUDEPATH}


### PR DESCRIPTION
Introduced by commit 06bf543224e83 but that didn't really bring anything using it.

LD_AS_NEEDED in .spec introduced in commit introducing the file, I'm skeptical is there any need.