### PR TITLE
Don't notify on already read messages

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -500,6 +500,16 @@ QString NotificationManager::filteredInboxAccountPath()
     return CommHistoryService::instance()->inboxFilterAccount();
 }
 
+void NotificationManager::removeNotificationToken(const QString &token)
+{
+    auto eraseFrom = std::find_if(m_notifications.begin(), m_notifications.end(), [&](PersonalNotification *notification) {
+            return ((notification->collection() == PersonalNotification::Messaging)
+                    && (notification->eventToken() == token));
+    });
+
+    deleteNotifications(&m_notifications, eraseFrom);
+}
+
 void NotificationManager::removeNotificationTypes(const QList<int> &types)
 {
     qCDebug(lcCommhistoryd) << Q_FUNC_INFO << types;

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -89,6 +89,11 @@ public:
     void removeNotificationTypes(const QList<int> &types);
 
     /*!
+     * \brief removes notification by event token
+     */
+    void removeNotificationToken(const QString &token);
+
+    /*!
      * \brief return group model with all conversations
      * \returns group model pointer
      */
@@ -115,6 +120,8 @@ public Q_SLOTS:
      * \param accountPath Notifications of this account are to be removed.
      */
     void removeNotifications(const QString &accountPath, const QList<int> &removeTypes = QList<int>());
+    void removeConversationNotifications(const CommHistory::Recipient &recipient,
+                                         CommHistory::Group::ChatType chatType=CommHistory::Group::ChatType::ChatTypeP2P);
 
 private Q_SLOTS:
     /*!
@@ -147,9 +154,6 @@ private:
 
     void resolveNotification(PersonalNotification *notification);
     void addNotification(PersonalNotification *notification);
-
-    void removeConversationNotifications(const CommHistory::Recipient &recipient,
-                                         CommHistory::Group::ChatType chatType);
 
     void syncNotifications();
     int pendingEventCount();

--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -1044,6 +1044,14 @@ TextChannelListener::DeliveryHandlingStatus TextChannelListener::handleDeliveryR
     int deliveryStatus = status.value<int>();
     qCDebug(lcCommhistoryd) << "[DELIVERY] Message delivery status: " << deliveryStatus;
 
+
+    if ((deliveryStatus == Tp::DeliveryStatusRead)
+        && (event.direction() == CommHistory::Event::Inbound)) {
+
+        NotificationManager::instance()->removeConversationNotifications(event.recipients().value(0));
+        return DeliveryHandlingResolved;
+    }
+
     switch (deliveryStatus) {
     case Tp::DeliveryStatusDelivered: {
         event.setStatus(CommHistory::Event::DeliveredStatus);
@@ -1072,14 +1080,14 @@ TextChannelListener::DeliveryHandlingStatus TextChannelListener::handleDeliveryR
         break;
     }
     case Tp::DeliveryStatusRead: {
-        event.setStatus(CommHistory::Event::DeliveredStatus); // Message is read by recipient so it defenetelly delivered
+        event.setStatus(CommHistory::Event::DeliveredStatus); // Message is read by recipient so it definitively delivered
         event.setStartTime(deliveryTime);
         event.setReadStatus(CommHistory::Event::ReadStatusRead);
 
         break;
     }
     case Tp::DeliveryStatusDeleted: {
-        event.setStatus(CommHistory::Event::DeliveredStatus); // Message is read by recipient so it defenetelly delivered
+        event.setStatus(CommHistory::Event::DeliveredStatus); // Message is read by recipient so it definitively delivered
         event.setStartTime(deliveryTime);
         event.setReadStatus(CommHistory::Event::ReadStatusDeleted);
 

--- a/tests/stubs/notificationmanager.cpp
+++ b/tests/stubs/notificationmanager.cpp
@@ -59,6 +59,15 @@ void NotificationManager::requestClass0Notification(const CommHistory::Event &)
 {
 }
 
+void NotificationManager::removeNotificationToken(const QString &token)
+{
+}
+
+void NotificationManager::removeConversationNotifications(const CommHistory::Recipient &recipient,
+                                                          CommHistory::Group::ChatType chatType)
+{
+}
+
 CommHistory::GroupModel* NotificationManager::groupModel()
 {
     return m_GroupModel;

--- a/tests/stubs/notificationmanager.h
+++ b/tests/stubs/notificationmanager.h
@@ -28,6 +28,9 @@ public:
                           CommHistory::Group::ChatType chatType = CommHistory::Group::ChatTypeP2P,
                           const QString &details = QString());
 
+    void removeNotificationToken(const QString &token);
+    void removeConversationNotifications(const CommHistory::Recipient &recipient,
+                                         CommHistory::Group::ChatType chatType=CommHistory::Group::ChatType::ChatTypeP2P);
     CommHistory::GroupModel* groupModel();
     void showVoicemailNotification(int count);
     void playClass0SMSAlert();


### PR DESCRIPTION
This is a patchset from noonien, being around since 2022:

> A [carbon enabled xmpp client](https://openrepos.net/content/noonien/telepathy-gabble-plus) will receive copies of the messages sent by another of your resources. If that resource supports and sends read markers, your carbon receiving client would be able to remove the related notifications.
>
>The commhistory-daemon is responsible for handling notifications and has been modified to remove them due to read notifications of other clients.

See https://openrepos.net/content/noonien/commhistory-daemon

I've been using this for some years (in combination with the mentioned telepathy-gabble-plus), and it works quite well.